### PR TITLE
Rename develop branch to development and add Code Climate and Cypress

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - develop
 
 jobs:
   deploy_production:

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -4,7 +4,7 @@ name: staging
 on:
   push:
     branches:
-      - develop
+      - development
 
 jobs:
   deploy_staging:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Neon Law Interface
 
-[![Maintainability](https://api.codeclimate.com/v1/badges/4088488b04552036f7a2/maintainability)](https://codeclimate.com/repos/5e7561df19c89d018d0039c7/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/4088488b04552036f7a2/test_coverage)](https://codeclimate.com/repos/5e7561df19c89d018d0039c7/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/a9de7883f94a89b722a5/maintainability)](https://codeclimate.com/github/NeonLaw/interface/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/a9de7883f94a89b722a5/test_coverage)](https://codeclimate.com/github/NeonLaw/interface/test_coverage)
 [![Continuous Integration](https://github.com/NeonLaw/interface/workflows/continuous_integration/badge.svg)](https://github.com/NeonLaw/interface/actions?query=workflow%3Acontinuous_integration)
 [![Staging](https://github.com/neonlaw/interface/workflows/staging/badge.svg)](https://github.com/NeonLaw/interface/actions?query=workflow%3Astaging)
 [![Production](https://github.com/neonlaw/interface/workflows/production/badge.svg)](https://github.com/NeonLaw/interface/actions?query=workflow%3Aproduction)

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
   "baseUrl": "http://localhost:8000",
-  "projectId": "htp9k8"
+  "projectId": "1g3j6w"
 }


### PR DESCRIPTION
We should try and be as clear as possible. In this case, the word
"development" is more formal than "develop" and is used as the main
branch of this repo.