### PR TITLE
Fix Staging environment

### DIFF
--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - development
+      - fix-staging-nginx
 
 jobs:
   deploy_staging:
@@ -12,6 +13,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Create staging_htpasswd file
+        run: echo "$STAGING_HTPASSWD" > staging_htpasswd
+        env:
+          STAGING_HTPASSWD: ${{ secrets.STAGING_HTPASSWD }}
+
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           project_id: neon-law-development
@@ -27,7 +34,6 @@ jobs:
 
       - name: Build the Docker image
         run: |-
-          echo ${{ secrets.STAGING_HTPASSWD }} > staging_htpasswd
           docker build \
             --tag "us.gcr.io/neon-law-development/interface:$GITHUB_SHA" \
             --tag "us.gcr.io/neon-law-development/interface:latest" \

--- a/nginx.conf
+++ b/nginx.conf
@@ -39,7 +39,7 @@ http {
 
   server {
     listen 80;
-    server_name  neonlaw.com  www.neonlaw.com;
+    server_name  www.neonlaw.com;
 
     autoindex off;
     charset utf-8;

--- a/staging.nginx.conf
+++ b/staging.nginx.conf
@@ -39,7 +39,7 @@ http {
 
   server {
     listen 80;
-    server_name  neonlaw.net  www.neonlaw.net;
+    server_name  www.neonlaw.net;
 
     autoindex off;
     charset utf-8;


### PR DESCRIPTION
On staging, we are experiencing this error in Nginx:

```
crypt_r() failed (22: Invalid argument)
```

This error is likely because crypt_r, a C utility used by Nginx, cannot
parse our htpasswd file for HTTP Basic authentication. This PR addresses
that by changing how we take the GitHub Actions environment variable and
adds it to the workflow, which then injects the Docker container.