### PR TITLE
Remove Cypress from GitHub Actions

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -27,14 +27,6 @@ jobs:
           CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
         with:
           coverageCommand: yarn test
-      - name: Cypress run
-        uses: cypress-io/github-action@v1
-        with:
-          record: true
-          start: yarn develop
-          wait-on: 'http://localhost:8000'
-        env:
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
       - name: Run Yarn Build.
         run: yarn build
         env:


### PR DESCRIPTION
Instead of running within GitHub Actions, Cypress can run via its own
GitHub-based hooks managed on cypress.io