### PR TITLE
Fix map view

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,3 @@
 AUTH0_CALLBACK=http://127.0.0.1:8000/callback/
 SITE_URL=http://127.0.0.1:8000
 API_URL=http://localhost:3000/graphql
-RE_CAPTCHA_KEY=6LcIQOMUAAAAADnq1diCtacmfogqriubjW0WmgN

--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,3 @@
 API_URL=https://api.neonlaw.net/graphql
 AUTH0_CALLBACK=https://www.neonlaw.com/callback/
 SITE_URL=https://www.neonlaw.com
-RE_CAPTCHA_KEY=6LcIQOMUAAAAADnq1diCtacmfogqriubjW0WmgN

--- a/.env.staging
+++ b/.env.staging
@@ -1,4 +1,3 @@
 API_URL=https://api.neonlaw.net/graphql
 AUTH0_CALLBACK=https://www.neonlaw.net/callback/
 SITE_URL=https://www.neonlaw.net
-RE_CAPTCHA_KEY=6LcIQOMUAAAAADnq1diCtacmfogqriubjW0WmgN

--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ under the same Apache License Version 2.0 that this repo is.
 
 ## Third Party SaaS Services
 
-This application uses Zendesk Chat to host chat with visitors and Google
-Analytics for data collection.
+This application uses:
+
+* Zendesk Chat to host chat with visitors
+* Google Analytics for data collection
+* Maps JavaScript API
 
 ## Staging Environment
 

--- a/src/components/vegasDirections.tsx
+++ b/src/components/vegasDirections.tsx
@@ -26,7 +26,7 @@ export const VegasDirections = () => {
     <div style={{ height: '35vh', width: '100%' }}>
       <GoogleMapReact
         bootstrapURLKeys={
-          { key: 'AIzaSyBWxquloo2cs9BJ4NXC7I2oBygORWl0gSc' }
+          { key: 'AIzaSyASkBFrDgag9OT2EXW8rVvNQ2WMgLTpWDA' }
         }
         defaultCenter={{ lat: 36.187, lng: -115.137 }}
         defaultZoom={13}

--- a/src/pages/pro-bono/justice-for-rickie-slaughter/index.mdx
+++ b/src/pages/pro-bono/justice-for-rickie-slaughter/index.mdx
@@ -1,4 +1,5 @@
 import { Image } from '@components/image';
+import { VegasDirections } from '@components/vegasDirections';
 
 <PublicLayout>
 
@@ -123,5 +124,7 @@ withheld a dispatch report that showed the contrary) is significant because
 it changed the actual timing of the event to favor the prosecutor's
 fictionalized version and caused Rickie to be wrongly convicted of a crime he
 did not commit.
+
+<VegasDirections />
 
 </PublicLayout>


### PR DESCRIPTION
Previously we had a map view that was working for our pro bono page
about Rickie Slaughter. This commit fixes that by adding an API key in
our neon-law-production account with access to maps from
https://www.neonlaw.com and adds the component on the right page.