### PR TITLE
loginAsPortalUser cypress test

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -33,6 +33,12 @@ jobs:
           start: yarn develop --verbose
           wait-on: "http://127.0.0.1:8000"
           wait-on-timeout: 180
+        env:
+          CYPRESS_AUTH_URL: ${{ secrets.CYPRESS_AUTH_URL }}
+          CYPRESS_AUDIENCE_URL: ${{ secrets.CYPRESS_AUDIENCE_URL }}
+          CYPRESS_AUTH_CLIENT_ID: ${{ secrets.CYPRESS_AUTH_CLIENT_ID }}
+          CYPRESS_AUTH_CLIENT_SECRET: ${{ secrets.CYPRESS_AUTH_CLIENT_SECRET }}
+          CYPRESS_PORTAL_USER_PASSWORD: ${{ secrets.CYPRESS_PORTAL_USER_PASSWORD }}
       - name: Run Yarn Build.
         run: yarn build
         env:

--- a/cypress/integration/portal.spec.js
+++ b/cypress/integration/portal.spec.js
@@ -1,0 +1,12 @@
+/// <reference types="cypress" />
+/* eslint-disable no-undef */
+
+describe('Visiting /portal', function () {
+  it('renders the profile is a user is logged in', function () {
+    cy.loginAsPortalUser().then(() => {
+      cy.visit('http://localhost:8000/portal');
+      cy.contains('Profile').click();
+      cy.url().should('include', '/portal/profile');
+    });
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,3 +1,6 @@
+/// <reference types="cypress" />
+/* eslint-disable no-undef */
+/* eslint-disable @typescript-eslint/camelcase */
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite
@@ -25,3 +28,56 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+Cypress.Commands.add(
+  'loginAsPortalUser',
+  () => {
+    cy.log('Logging in as portal@neonlaw.com');
+    const options = {
+      body: {
+        'audience': Cypress.env('AUDIENCE_URL'),
+        'client_id': Cypress.env('AUTH_CLIENT_ID'),
+        'client_secret': Cypress.env('AUTH_CLIENT_SECRET'),
+        'grant_type': 'http://auth0.com/oauth/grant-type/password-realm',
+        'password': Cypress.env('PORTAL_USER_PASSWORD'),
+        realm: 'Username-Password-Authentication',
+        'scope': 'openid profile email',
+        'username': 'portal@neonlaw.com',
+      },
+      method: 'POST',
+      url: Cypress.env('AUTH_URL'),
+    };
+    cy.request(options).then(({ body }) => {
+      const { access_token, expires_in, id_token } = body;
+
+      cy.server();
+
+      // intercept Auth0 request for token and return what we have
+      cy.route({
+        method: 'POST',
+        response: {
+          access_token: access_token,
+          expires_in: expires_in,
+          id_token: id_token,
+          scope: 'openid profile email',
+          token_type: 'Bearer',
+        },
+        url: 'oauth/token',
+      });
+      // Auth0 SPA SDK will check for value in cookie to get appState
+      // add validate nonce (which has been removed for simplicity)
+      const stateId = 'test';
+      cy.setCookie(
+        `a0.spajs.txs.${stateId}`,
+        encodeURIComponent(JSON.stringify({
+          'appState': { targetUrl: '/' },
+          'audience': 'default',
+          'redirect_uri': 'http://127.0.0.1:8000',
+          'scope': 'openid profile email',
+        }))
+      ).then(() => {
+        cy.visit(`/?code=test&state=${stateId}`);
+      });
+    });
+  }
+);

--- a/src/pages/portal/profile.tsx
+++ b/src/pages/portal/profile.tsx
@@ -1,0 +1,25 @@
+import {
+  Heading,
+  Text,
+} from '@chakra-ui/core';
+import { PortalLayout } from '@layouts/portal';
+import React from 'react';
+import { useIntl } from 'gatsby-plugin-intl';
+
+const PortalPage = () => {
+  const intl = useIntl();
+  return (
+    <PortalLayout>
+      <Heading textAlign="center" marginBottom="20px">
+        {intl.formatMessage({ id: 'pages_portal.heading' })}
+      </Heading>
+
+
+      <Text>
+        {intl.formatMessage({ id: 'pages_portal.text' })}
+      </Text>
+    </PortalLayout>
+  );
+};
+
+export default PortalPage;


### PR DESCRIPTION
This test uses code from [this
project](https://github.com/dunson062786/login-programmatically-into-auth0-with-cypress/blob/master/cypress/integration/login_spec.js)
to use the Auth0 management API to log in via a post request and create
an access_token that we can use to test user sessions.