### PR TITLE
change audience url

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -35,7 +35,6 @@ jobs:
           wait-on-timeout: 180
         env:
           CYPRESS_AUTH_URL: ${{ secrets.CYPRESS_AUTH_URL }}
-          CYPRESS_AUDIENCE_URL: ${{ secrets.CYPRESS_AUDIENCE_URL }}
           CYPRESS_AUTH_CLIENT_ID: ${{ secrets.CYPRESS_AUTH_CLIENT_ID }}
           CYPRESS_AUTH_CLIENT_SECRET: ${{ secrets.CYPRESS_AUTH_CLIENT_SECRET }}
           CYPRESS_PORTAL_USER_PASSWORD: ${{ secrets.CYPRESS_PORTAL_USER_PASSWORD }}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -35,7 +35,7 @@ Cypress.Commands.add(
     cy.log('Logging in as portal@neonlaw.com');
     const options = {
       body: {
-        'audience': Cypress.env('AUDIENCE_URL'),
+        'audience': 'https://api.neonlaw.com',
         'client_id': Cypress.env('AUTH_CLIENT_ID'),
         'client_secret': Cypress.env('AUTH_CLIENT_SECRET'),
         'grant_type': 'http://auth0.com/oauth/grant-type/password-realm',


### PR DESCRIPTION
The Auth0 audience in all of our environments should be the same,
especially figuring that we will likely have only one API server.