### PR TITLE
pass envvars to gatsby build command

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
-AUTH0_CALLBACK=http://127.0.0.1:8000/callback/
+GATSBY_AUTH0_CALLBACK=http://127.0.0.1:8000/callback/
+GATSBY_AUTH0_DOMAIN=neon-law-testing.auth0.com
+GATSBY_AUTH0_CLIENT_ID=dplmcTTWBbkd9j5jFd1LMr26c25Iugv7
 SITE_URL=http://127.0.0.1:8000
 API_URL=https://api.neonlaw.net/graphql
-AUTH0_DOMAIN=neon-law-testing.auth0.com
-AUTH0_CLIENT_ID=dplmcTTWBbkd9j5jFd1LMr26c25Iugv7

--- a/.env.development-docker
+++ b/.env.development-docker
@@ -1,5 +1,0 @@
-AUTH0_CALLBACK=http://127.0.0.1:8000/callback/
-SITE_URL=http://127.0.0.1:8000
-API_URL=http://127.0.0.1:3000/graphql
-AUTH0_DOMAIN=neon-law-testing.auth0.com
-AUTH0_CLIENT_ID=dplmcTTWBbkd9j5jFd1LMr26c25Iugv7

--- a/.env.staging
+++ b/.env.staging
@@ -1,4 +1,2 @@
 API_URL=https://api.neonlaw.net/graphql
 SITE_URL=https://www.neonlaw.net
-AUTH0_DOMAIN=neon-law-testing.auth0.com
-AUTH0_CLIENT_ID=dplmcTTWBbkd9j5jFd1LMr26c25Iugv7

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - development
+      - pass-envvars
 
 jobs:
   deploy_development_docker_image:
@@ -16,9 +17,16 @@ jobs:
         run: |-
           docker build \
             --tag "neonlaw/interface:latest" \
-            --build-arg GATSBY_ACTIVE_ENV=development-docker \
+            --build-arg GATSBY_ACTIVE_ENV=development \
+            --build-arg GATSBY_AUTH0_CALLBACK="$GATSBY_AUTH0_CALLBACK" \
+            --build-arg GATSBY_AUTH0_DOMAIN="$GATSBY_AUTH0_DOMAIN" \
+            --build-arg GATSBY_AUTH0_CLIENT_ID="$GATSBY_AUTH0_CLIENT_ID" \
             -f Dockerfile \
             .
+        env:
+          GATSBY_AUTH0_CALLBACK: http://127.0.0.1:8000/callback/
+          GATSBY_AUTH0_DOMAIN: neon-law-testing.auth0.com
+          GATSBY_AUTH0_CLIENT_ID: http://127.0.0.1:3000/graphql
 
       - name: Authenticate to the Docker Hub
         run: |-

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - development
-      - pass-envvars
 
 jobs:
   deploy_development_docker_image:

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -30,16 +30,16 @@ jobs:
           docker build \
             --tag "us.gcr.io/neon-law-production/interface:$GITHUB_SHA" \
             --tag "us.gcr.io/neon-law-production/interface:latest" \
-            --build-arg AUTH0_CALLBACK="$AUTH0_CALLBACK" \
-            --build-arg AUTH0_DOMAIN="$AUTH0_DOMAIN" \
-            --build-arg AUTH0_CLIENT_ID="$AUTH0_CLIENT_ID" \
+            --build-arg GATSBY_AUTH0_CALLBACK="$GATSBY_AUTH0_CALLBACK" \
+            --build-arg GATSBY_AUTH0_DOMAIN="$GATSBY_AUTH0_DOMAIN" \
+            --build-arg GATSBY_AUTH0_CLIENT_ID="$GATSBY_AUTH0_CLIENT_ID" \
             --build-arg GATSBY_ACTIVE_ENV=production \
             -f Dockerfile \
             .
         env:
-          AUTH0_CALLBACK: ${{ secrets.PRODUCTION_AUTH0_CALLBACK }}
-          AUTH0_DOMAIN: ${{ secrets.PRODUCTION_AUTH0_DOMAIN }}
-          AUTH0_CLIENT_ID: ${{ secrets.PRODUCTION_AUTH0_CLIENT_ID }}
+          GATSBY_AUTH0_CALLBACK: ${{ secrets.PRODUCTION_AUTH0_CALLBACK }}
+          GATSBY_AUTH0_DOMAIN: ${{ secrets.PRODUCTION_AUTH0_DOMAIN }}
+          GATSBY_AUTH0_CLIENT_ID: ${{ secrets.PRODUCTION_AUTH0_CLIENT_ID }}
 
       - name: Push the Docker image to Google Container Registry
         run: |-

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - development
-      - pass-envvars
 
 jobs:
   deploy_staging:

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - development
+      - pass-envvars
 
 jobs:
   deploy_staging:
@@ -36,16 +37,16 @@ jobs:
           docker build \
             --tag "us.gcr.io/neon-law-staging/interface:$GITHUB_SHA" \
             --tag "us.gcr.io/neon-law-staging/interface:latest" \
-            --build-arg AUTH0_CALLBACK="$AUTH0_CALLBACK" \
-            --build-arg AUTH0_DOMAIN="$AUTH0_DOMAIN" \
-            --build-arg AUTH0_CLIENT_ID="$AUTH0_CLIENT_ID" \
+            --build-arg GATSBY_AUTH0_CALLBACK="$GATSBY_AUTH0_CALLBACK" \
+            --build-arg GATSBY_AUTH0_DOMAIN="$GATSBY_AUTH0_DOMAIN" \
+            --build-arg GATSBY_AUTH0_CLIENT_ID="$GATSBY_AUTH0_CLIENT_ID" \
             --build-arg GATSBY_ACTIVE_ENV=staging \
             -f staging.Dockerfile \
             .
         env:
-          AUTH0_CALLBACK: ${{ secrets.STAGING_AUTH0_CALLBACK }}
-          AUTH0_DOMAIN: ${{ secrets.STAGING_AUTH0_DOMAIN }}
-          AUTH0_CLIENT_ID: ${{ secrets.STAGING_AUTH0_CLIENT_ID }}
+          GATSBY_AUTH0_CALLBACK: ${{ secrets.STAGING_AUTH0_CALLBACK }}
+          GATSBY_AUTH0_DOMAIN: ${{ secrets.STAGING_AUTH0_DOMAIN }}
+          GATSBY_AUTH0_CLIENT_ID: ${{ secrets.STAGING_AUTH0_CLIENT_ID }}
 
       - name: Push the Docker image to Google Container Registry
         run: |-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,14 @@
-ARG GATSBY_ACTIVE_ENV=production
-
 FROM node:12-buster AS build
 
 ARG GATSBY_ACTIVE_ENV
-ARG AUTH0_CALLBACK
-ARG AUTH0_DOMAIN
-ARG AUTH0_CLIENT_ID
+ARG GATSBY_AUTH0_CALLBACK
+ARG GATSBY_AUTH0_DOMAIN
+ARG GATSBY_AUTH0_CLIENT_ID
 
 WORKDIR /app
 ADD . ./
-RUN yarn install --ignore-optional
+RUN yarn install --ignore-optional --silent
 RUN yarn build
-RUN ls -la **/*
 
 FROM nginx
 COPY --from=build /app/public /usr/share/nginx/html

--- a/src/utils/authenticationContext.tsx
+++ b/src/utils/authenticationContext.tsx
@@ -39,9 +39,9 @@ export class AuthenticationProvider extends Component {
   config = {
     audience: 'https://api.neonlaw.com',
     /* eslint-disable @typescript-eslint/camelcase */
-    client_id: process.env.AUTH0_CLIENT_ID as string,
-    domain: process.env.AUTH0_DOMAIN as string,
-    redirect_uri: process.env.AUTH0_CALLBACK,
+    client_id: process.env.GATSBY_AUTH0_CLIENT_ID as string,
+    domain: process.env.GATSBY_AUTH0_DOMAIN as string,
+    redirect_uri: process.env.GATSBY_AUTH0_CALLBACK,
     /* eslint-enable @typescript-eslint/camelcase */
     responseType: 'token id_token',
     scope: 'openid profile email'

--- a/staging.Dockerfile
+++ b/staging.Dockerfile
@@ -1,17 +1,14 @@
-ARG GATSBY_ACTIVE_ENV=production
-
 FROM node:12-buster AS build
 
 ARG GATSBY_ACTIVE_ENV
-ARG AUTH0_CALLBACK
-ARG AUTH0_DOMAIN
-ARG AUTH0_CLIENT_ID
+ARG GATSBY_AUTH0_CALLBACK
+ARG GATSBY_AUTH0_DOMAIN
+ARG GATSBY_AUTH0_CLIENT_ID
 
 WORKDIR /app
 ADD . ./
-RUN yarn install --ignore-optional
+RUN yarn install --ignore-optional --silent
 RUN yarn build
-RUN ls -la **/*
 
 FROM nginx
 COPY --from=build /app/public /usr/share/nginx/html


### PR DESCRIPTION
It seems like the redirect url is not being passed in, this is an
attempt to remove all envvars from dotenv's `env.staging` and use build
arguments to source the proper envvars in gatsby build.