### PR TITLE
fix API_URL for production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,2 @@
-API_URL=https://api.neonlaw.net/graphql
+API_URL=https://api.neonlaw.com/graphql
 SITE_URL=https://www.neonlaw.com


### PR DESCRIPTION
This is a hotfix to correct an error where the production interface is pointing to the staging API