### PR TITLE
Remove master branch

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - development
-      - master
+      - production
   pull_request:
     branches:
       - development
@@ -29,7 +29,7 @@ jobs:
       - name: Security Scanning
         uses: ajinabraham/njsscan-action@v5
         with:
-          args: '.'
+          args: "."
       - name: Test & publish code coverage
         uses: paambaati/codeclimate-action@v2.5.5
         env:

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -4,7 +4,7 @@ name: production
 on:
   push:
     branches:
-      - master
+      - production
 
 jobs:
   deploy_production:


### PR DESCRIPTION
There are compelling arguments why as developers we should rename the
`master` branch to something else to move away from slavery-based
rhetoric. This commit renames our `master` branch to the `production`
branch, since this is the code shipped to production.