### PR TITLE
added featured image support to blog posts

### DIFF
--- a/src/layouts/blog.tsx
+++ b/src/layouts/blog.tsx
@@ -20,6 +20,8 @@ import { graphql } from 'gatsby';
 
 const shortcodes = { Link };
 import { publicClient } from '@utils/authenticationContext';
+import Img from "gatsby-image"
+
 
 const BlogLayout = ({ data: { mdx } }) => {
   return (
@@ -50,6 +52,14 @@ const BlogLayout = ({ data: { mdx } }) => {
                           </Heading>
                           <EditOnGithub path={mdx.frontmatter.slug} />
                         </Flex>
+                        <Box
+                          borderWidth="1px"
+                          rounded="lg"
+                          overflow="hidden"
+                        >
+                          {mdx.frontmatter.featuredImage ? <Img fluid={mdx.frontmatter.featuredImage.childImageSharp.fluid} /> : null}
+
+                        </Box>
                         <MDXProvider components={shortcodes}>
                           <MDXRenderer>{mdx.body}</MDXRenderer>
                         </MDXProvider>
@@ -80,6 +90,14 @@ const BlogLayout = ({ data: { mdx } }) => {
                         </Heading>
                         <EditOnGithub path={mdx.frontmatter.slug} />
                       </Flex>
+                      <Box
+                        borderWidth="1px"
+                        rounded="lg"
+                        overflow="hidden"
+                      >
+                        {mdx.frontmatter.featuredImage ? <Img fluid={mdx.frontmatter.featuredImage.childImageSharp.fluid} /> : null}
+
+                      </Box>
                       <MDXProvider components={shortcodes}>
                         <MDXRenderer>{mdx.body}</MDXRenderer>
                       </MDXProvider>
@@ -108,6 +126,13 @@ export const pageQuery = graphql`
       frontmatter {
         title
         slug
+        featuredImage {
+          childImageSharp {
+            fluid(maxWidth: 800, quality: 100) {
+              ...GatsbyImageSharpFluid
+            }
+          }
+        }
       }
     }
   }

--- a/src/posts/coronavirus.mdx
+++ b/src/posts/coronavirus.mdx
@@ -1,5 +1,6 @@
 ---
 title: Coronavirus
+featuredImage: ../images/coronavirus.jpg
 slug: /coronavirus
 updatedAt: "2020-04-01"
 tags: musings,coronavirus


### PR DESCRIPTION
- Added featured image support to blog posts pages .
- The featured image works for any other page that uses markdown and contains **featured image** frontmatter.